### PR TITLE
Write resume= GRUB parameter as partition uuid.

### DIFF
--- a/agent/hibagent
+++ b/agent/hibagent
@@ -98,6 +98,11 @@ def get_swap_space():
         return int(lines[0].split()[2]) * 1024
 
 
+def get_partuuid(device):
+    return check_output(
+        ['lsblk', '-dno', 'PARTUUID', device]).decode('ascii').strip()
+
+
 def patch_grub_config(swap_device, offset, grub_file, grub2_dir):
     log("Updating GRUB to use the device %s with offset %d for resume" % (swap_device, offset))
     lines = []
@@ -127,6 +132,8 @@ def patch_grub_config(swap_device, offset, grub_file, grub2_dir):
     # Do GRUB2 update as well
     if grub2_dir and os.path.exists(grub2_dir):
         offset_file = os.path.join(grub2_dir, '99-set-swap.cfg')
+        if swap_device.startswith("/dev"):
+            swap_device = "PARTUUID=%s" % get_partuuid(swap_device)
         with open(offset_file, 'w') as fl:
             fl.write('GRUB_CMDLINE_LINUX_DEFAULT="$GRUB_CMDLINE_LINUX_DEFAULT no_console_suspend=1 '
                      'resume_offset=%d resume=%s"\n' % (offset, swap_device))


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Set "resume=PARTUUID=<uuid>", instead of "resume=/dev/root"

tested on ubuntu 20.04, in ```/boot/grub/grub.cfg``` after running agent

before
```
...no_console_suspend=1 resume_offset=466944 resume=/dev/root
```

after
```
...no_console_suspend=1 resume_offset=499712 resume=PARTUUID=4aa57d6f-01
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
