### PR TITLE
 Update the Spot hibernate agent to do nothing if ODH is configured

### DIFF
--- a/agent/hibagent
+++ b/agent/hibagent
@@ -18,6 +18,7 @@ import os
 import struct
 import sys
 import syslog
+import requests
 from subprocess import check_call, check_output
 from threading import Thread
 from math import ceil
@@ -507,7 +508,7 @@ def get_imds_token(seconds=21600):
     token_url = '{}/{}'.format(IMDS_BASEURL, IMDS_API_TOKEN_PATH)
     response = requests.put(token_url, headers=request_header)
     response.close()
-    if response.status_code != 200:
+    if not response.ok:
         return None
 
     return response.text
@@ -524,7 +525,7 @@ def hibernation_enabled():
     response = requests.get("{}/{}".format(IMDS_BASEURL, IMDS_SPOT_ACTION_PATH),
                  headers=request_header)
     response.close()
-    if response.status_code != 200 or response.text.lower() == "false":
+    if not response.ok or response.text.lower() == "false":
         return False
 
     log("Hibernation Configured Flag found")

--- a/agent/hibagent
+++ b/agent/hibagent
@@ -39,6 +39,9 @@ SWAP_RESERVED_SIZE = 16384
 log_to_syslog = True
 log_to_stderr = True
 
+IMDS_BASEURL = 'http://169.254.169.254'
+IMDS_API_TOKEN_PATH = 'latest/api/token'
+IMDS_SPOT_ACTION_PATH = 'latest/meta-data/hibernation/configured'
 
 def log(message):
     if log_to_syslog:
@@ -497,6 +500,36 @@ def adjust_pm_timeout(timeout):
         log("Failed to adjust pm_freeze_timeout to %d. Error: %s" % (timeout, str(e)))
         exit(1)
 
+def get_imds_token(seconds=21600):
+    """ Get a token to access instance metadata. """
+    log("Requesting new IMDSv2 token.")
+    request_header = {'X-aws-ec2-metadata-token-ttl-seconds': '{}'.format(seconds)}
+    token_url = '{}/{}'.format(IMDS_BASEURL, IMDS_API_TOKEN_PATH)
+    response = requests.put(token_url, headers=request_header)
+    response.close()
+    if response.status_code != 200:
+        return None
+
+    return response.text
+
+def hibernation_enabled():
+    """Returns a boolean indicating whether hibernation-option.configured is enabled or not."""
+
+    imds_token = get_imds_token()
+    if imds_token is None:
+        # IMDS http endpoint is disabled
+        return False
+
+    request_header = {'X-aws-ec2-metadata-token': imds_token}
+    response = requests.get("{}/{}".format(IMDS_BASEURL, IMDS_SPOT_ACTION_PATH),
+                 headers=request_header)
+    response.close()
+    if response.status_code != 200 or response.text.lower() == "false":
+        return False
+
+    log("Hibernation Configured Flag found")
+
+    return True
 
 def main():
     # Parse arguments
@@ -535,6 +568,11 @@ def main():
     log_to_syslog = config.log_to_syslog
 
     log("Effective config: %s" % config)
+
+    # Let's first check if we need to kill the Spot Hibernate Agent
+    if hibernation_enabled():
+        log("Spot Instance Launch has enabled Hibernation Configured Flag. hibagent exiting!!")
+        exit(0)
 
     target_swap_size = config.swap_mb * 1024 * 1024
     ram_bytes = os.sysconf('SC_PAGE_SIZE') * os.sysconf('SC_PHYS_PAGES')

--- a/agent/hibagent
+++ b/agent/hibagent
@@ -518,6 +518,7 @@ def hibernation_enabled():
 
     imds_token = get_imds_token()
     if imds_token is None:
+        log("IMDS_V2 http endpoint is disabled")
         # IMDS http endpoint is disabled
         return False
 

--- a/agent/hibagent
+++ b/agent/hibagent
@@ -508,7 +508,7 @@ def get_imds_token(seconds=21600):
     token_url = '{}/{}'.format(IMDS_BASEURL, IMDS_API_TOKEN_PATH)
     response = requests.put(token_url, headers=request_header)
     response.close()
-    if not response.ok:
+    if response.status_code != requests.codes.ok:
         return None
 
     return response.text
@@ -525,7 +525,7 @@ def hibernation_enabled():
     response = requests.get("{}/{}".format(IMDS_BASEURL, IMDS_SPOT_ACTION_PATH),
                  headers=request_header)
     response.close()
-    if not response.ok or response.text.lower() == "false":
+    if response.status_code != requests.codes.ok or response.text.lower() == "false":
         return False
 
     log("Hibernation Configured Flag found")


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Update the Spot hibernate agent to do nothing if ODH is configured
to avoid any conflicts between two agents

*Testing 
Modified Spot hibernate agent on two different spot instances that have hibernate-option.configured true or false to test the change. Successfully verify the hibernate-option.configured meta-data of each instances


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
